### PR TITLE
Spec generating a pattern string from a part list.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -995,6 +995,74 @@ To <dfn>escape a regexp string</dfn> given a string |input|:
 
 <h3 id=converting-part-lists-to-pattern-strings>Converting Part Lists to Pattern Strings</h3>
 
+<div algorithm>
+To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] |part list| and [=/options=] |options|:
+
+  1. Let |result| be the empty string.
+  1. [=list/For each=] |part| of |part list|:
+    1. If |part|'s [=part/type=] is "<a for=part/type>`fixed-text`</a>" then:
+      1. If |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>" then:
+        1. Append the result of running [=escape a pattern string=] given |part|'s [=part/value=] to the end of |result|.
+        1. [=Continue=].
+      1. Append "`{`" to the end of |result|.
+      1. Append the result of running [=escape a pattern string=] given |part|'s [=part/value=] to the end of |result|.
+      1. Append "`}`" to the end of |result|.
+      1. Append the result of running [=convert a modifier to a string=] given |part|'s [=part/modifier=] to the end of |result|.
+      1. [=Continue=].
+    1. Let |needs grouping| be true if at least one of the following are true, otherwise let it be false:
+      <ul>
+        <li>|part|'s [=part/suffix=] is not the empty string.</li>
+        <li>|part|'s [=part/prefix=] is not the empty string and is not |options|'s [=options/prefix code point=].
+      </ul>
+    1. [=Assert=]: |part|'s [=part/name=] is not the empty string or null.
+    1. Let |custom name| be true if |part|'s [=part/name=][0] is not an [=ASCII digit=].
+    1. If |needs grouping| is true, then append "`{`" to the end of |result|.
+    1. Append the result of running [=escape a pattern string=] given |part|'s [=part/prefix=] to the end of |result|.
+    1. If |custom name| is true:
+      1. Append "`:`" to the end of |result|.
+      1. Append |part|'s [=part/name=] to the end of |result|.
+    1. If |part|'s [=part/type=] is "<a for=part/type>`regexp`</a>" then:
+      1. Append "`(`" to the end of |result|.
+      1. Append |part|'s [=part/value=] to the end of |result|.
+      1. Append "`)`" to the end of |result|.
+    1. Else if |part|'s [=part/type=] is "<a for=part/type>`segment-wildcard`</a>" and |custom name| is false:
+      1. Append "`(`" to the end of |result|.
+      1. Append the result of running [=generate a segment wildcard regexp=] given |options| to the end of |result|.
+      1. Append "`)`" to the end of |result|.
+    1. Else if |part|'s [=part/type=] is "<a for=part/type>`full-wildcard`</a>":
+      1. If |custom name| is true:
+        1. Append "`(`" to the end of |result|.
+        1. Append [=full wildcard regexp value=] to the end of |result|.
+        1. Append "`)`" to the end of |result|.
+      1. Else append "`*`" to the end of |result|.
+    1. Append the result of running [=escape a pattern string=] given |part|'s [=part/suffix=] to the end of |result|.
+    1. If |needs grouping| is true, then append "`}`" to the end of |result|.
+    1. Append the result of running [=convert a modifier to a string=] give |part|'s [=part/modifier=] to the end of |result|.
+  1. Return |result|.
+</div>
+
+<div algorithm>
+To <dfn>escape a pattern string</dfn> given a string |input|:
+
+  1. [=Assert=]: |input| is an [=ASCII string=].
+  1. Let |result| be the empty string.
+  1. Let |index| be 0.
+  1. While |index| is less than |input|'s [=string/length=]:
+    1. Let |c| be |input|[|index|].
+    1. If |c| is one of "`+`", "`*`", "`?`", "`:`", "`{`", "`}`", "`(`", "`)`", or "<code>\</code>", then append "<code>\</code>" to the end of |result|.
+    1. Append |c| to the end of |result|.
+  1. Return |result|.
+</div>
+
+<div algorithm>
+To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier|:
+
+  1. If |modifier| is "<a for=part/modifier>`zero-or-more`</a>", then return "`*`".
+  1. If |modifier| is "<a for=part/modifier>`optional`</a>", then return "`?`".
+  1. If |modifier| is "<a for=part/modifier>`one-or-more`</a>", then return "`+`".
+  1. Return the empty string.
+</div>
+
 <h2 id=patching>Patching</h2>
 
 This spec depends on factoring out the {{URL/pathname}} getter steps into a new exported algorithm, <dfn for=url>API pathname string</dfn>, that operates on a [=URL record=].


### PR DESCRIPTION
@domenic Here is a PR to add pattern string generation.  It depends on the parser PR landing first, so it can wait until that is merged.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/64.html" title="Last updated on Jul 29, 2021, 7:14 PM UTC (2e0eae9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/64/642585d...2e0eae9.html" title="Last updated on Jul 29, 2021, 7:14 PM UTC (2e0eae9)">Diff</a>