### PR TITLE
Add missing index increment in escape a regexp string. (Fixes #71)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1304,6 +1304,7 @@ To <dfn>escape a regexp string</dfn> given a string |input|:
   1. Let |index| be 0.
   1. While |index| is less than |input|'s [=string/length=]:
     1. Let |c| be |input|[|index|].
+    1. Increment |index| by 1.
     1. If |c| is one of "`.`", "`+`", "`*`", "`?`", "`^`", "`$`", "`{`", "`}`", "`(`", "`)`", "`[`", "`]`", "`|`", "`/`", or "<code>\</code>", then append "<code>\</code>" to the end of |result|.
     1. Append |c| to the end of |result|.
   1. Return |result|.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/78.html" title="Last updated on Aug 12, 2021, 3:54 PM UTC (261a622)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/78/bd172d6...261a622.html" title="Last updated on Aug 12, 2021, 3:54 PM UTC (261a622)">Diff</a>