### PR TITLE
Fix an add-a-token to be add-a-token-with-default-position-and-length…

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -899,7 +899,7 @@ A [=tokenizer=] has an associated <dfn for=tokenizer>code point</dfn>, a Unicode
         1. Run [=process a tokenizing error=] given |tokenizer|, |regexp start|, and |tokenizer|'s [=tokenizer/index=].
         1. [=Continue=].
       1. Run [=add a token=] given |tokenizer|, "<a for=token/type>`regexp`</a>", |regexp position|, |regexp start|, and |regexp length|.
-    1. Run [=add a token=] given |tokenizer| and "<a for=token/type>`char`</a>".
+    1. Run [=add a token with default position and length=] given |tokenizer| and "<a for=token/type>`char`</a>".
   1. Run [=add a token with default length=] given |tokenizer|, "<a for=token/type>`end`</a>", |tokenizer|'s [=tokenizer/index=], and |tokenizer|'s [=tokenizer/index=].
   1. Return |tokenizer|'s [=tokenizer/token list=].
 </div>


### PR DESCRIPTION
…. (Fixes #72)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/79.html" title="Last updated on Aug 12, 2021, 4:53 PM UTC (10b9f00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/79/9291dcc...10b9f00.html" title="Last updated on Aug 12, 2021, 4:53 PM UTC (10b9f00)">Diff</a>