### PR TITLE
Reorder argument to compile-a-component to match how they were actual…

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -323,7 +323,7 @@ A [=component=] has an associated <dfn for=component>regular expression</dfn>, a
 A [=component=] has an associated <dfn for=component>group name list</dfn>, a [=list=] of strings, which must be set upon creation.
 
 <div algorithm>
-  To <dfn>compile a component</dfn> given a string |input|, [=/options=] |options|, and [=/encoding callback=] |encoding callback|:
+  To <dfn>compile a component</dfn> given a string |input|, [=/encoding callback=] |encoding callback|, and [=/options=] |options|:
 
   1. Let |part list| be the result of running [=parse a pattern string=] given |input|, |options|, and |encoding callback|.
   1. Let (|regular expression string|, |name list|) be the result of running [=generate a regular expression and name list=] given |part list| and |options|.


### PR DESCRIPTION
…ly getting passed. (Fixed #82)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/84.html" title="Last updated on Aug 12, 2021, 7:10 PM UTC (125023f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/84/f3e8f03...125023f.html" title="Last updated on Aug 12, 2021, 7:10 PM UTC (125023f)">Diff</a>