### PR TITLE
Add a note that implementations do not have to use regexps to match.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -328,7 +328,7 @@ A [=component=] has an associated <dfn for=component>group name list</dfn>, a [=
   1. Let |part list| be the result of running [=parse a pattern string=] given |input|, |options|, and |encoding callback|.
   1. Let (|regular expression string|, |name list|) be the result of running [=generate a regular expression and name list=] given |part list| and |options|.
   1. Let |regular expression| be [$RegExpCreate$](|regular expression string|, "`u`").  If this throws an exception, catch it, and throw a {{TypeError}}.
-    <p class="note allow-2119">The specification uses regular expressions to perform all matching, but this is not required.  Implementations are free to perform matching directly against the [=/part list=] when possible; e.g. when there are no custom regexp matching groups.  If there are custom regular expressions, however, its important that they should be immediately evaluated in [=compile a component=] algorithm so an error can be thrown if they are invalid.
+    <p class="note allow-2119">The specification uses regular expressions to perform all matching, but this is not required.  Implementations are free to perform matching directly against the [=/part list=] when possible; e.g. when there are no custom regexp matching groups.  If there are custom regular expressions, however, its important that they should be immediately evaluated in the [=compile a component=] algorithm so an error can be thrown if they are invalid.
   1. Let |pattern string| be the result of running [=generate a pattern string=] given |part list| and |options|.
   1. Return a new [=component=] whose [=component/pattern string=] is |pattern string|, [=component/regular expression=] is |regular expression|, and [=component/group name list=] is |name list|.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -328,6 +328,7 @@ A [=component=] has an associated <dfn for=component>group name list</dfn>, a [=
   1. Let |part list| be the result of running [=parse a pattern string=] given |input|, |options|, and |encoding callback|.
   1. Let (|regular expression string|, |name list|) be the result of running [=generate a regular expression and name list=] given |part list| and |options|.
   1. Let |regular expression| be [$RegExpCreate$](|regular expression string|, "`u`").  If this throws an exception, catch it, and throw a {{TypeError}}.
+    <p class="note allow-2119">The specification uses regular expressions to perform all matching, but this is not required.  Implementations are free to perform matching directly against the [=/part list=] when possible; e.g. when there are no custom regexp matching groups.  If there are custom regular expressions, however, its important that they should be immediately evaluated in [=compile a component=] algorithm so an error can be thrown if they are invalid.
   1. Let |pattern string| be the result of running [=generate a pattern string=] given |part list| and |options|.
   1. Return a new [=component=] whose [=component/pattern string=] is |pattern string|, [=component/regular expression=] is |regular expression|, and [=component/group name list=] is |name list|.
 </div>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/85.html" title="Last updated on Aug 12, 2021, 8:00 PM UTC (eaf49cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/85/68b66a0...eaf49cc.html" title="Last updated on Aug 12, 2021, 8:00 PM UTC (eaf49cc)">Diff</a>