### PR TITLE
Convert null pattern strings to '*'. (Fixes #117)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -363,6 +363,7 @@ A [=component=] has an associated <dfn for=component>group name list</dfn>, a [=
 <div algorithm>
   To <dfn>compile a component</dfn> given a string |input|, [=/encoding callback=] |encoding callback|, and [=/options=] |options|:
 
+  1. If |input| is null, then set |input| to "`*`".
   1. Let |part list| be the result of running [=parse a pattern string=] given |input|, |options|, and |encoding callback|.
   1. Let (|regular expression string|, |name list|) be the result of running [=generate a regular expression and name list=] given |part list| and |options|.
   1. Let |regular expression| be [$RegExpCreate$](|regular expression string|, "`u`").  If this throws an exception, catch it, and throw a {{TypeError}}.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/119.html" title="Last updated on Sep 3, 2021, 7:18 PM UTC (ed3d745)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/119/8faa51b...ed3d745.html" title="Last updated on Sep 3, 2021, 7:18 PM UTC (ed3d745)">Diff</a>