### PR TITLE
Continue after tokenizing name or regexp

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -968,7 +968,7 @@ A [=tokenizer=] has an associated <dfn for=tokenizer>code point</dfn>, a Unicode
         1. [=Continue=].
       1. Run [=add a token=] given |tokenizer|, "<a for=token/type>`regexp`</a>", |regexp position|, |regexp start|, and |regexp length|.
       1. [=Continue=].
-  1. Run [=add a token with default position and length=] given |tokenizer| and "<a for=token/type>`char`</a>".
+    1. Run [=add a token with default position and length=] given |tokenizer| and "<a for=token/type>`char`</a>".
   1. Run [=add a token with default length=] given |tokenizer|, "<a for=token/type>`end`</a>", |tokenizer|'s [=tokenizer/index=], and |tokenizer|'s [=tokenizer/index=].
   1. Return |tokenizer|'s [=tokenizer/token list=].
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -967,7 +967,8 @@ A [=tokenizer=] has an associated <dfn for=tokenizer>code point</dfn>, a Unicode
         1. Run [=process a tokenizing error=] given |tokenizer|, |regexp start|, and |tokenizer|'s [=tokenizer/index=].
         1. [=Continue=].
       1. Run [=add a token=] given |tokenizer|, "<a for=token/type>`regexp`</a>", |regexp position|, |regexp start|, and |regexp length|.
-    1. Run [=add a token with default position and length=] given |tokenizer| and "<a for=token/type>`char`</a>".
+      1. [=Continue=].
+  1. Run [=add a token with default position and length=] given |tokenizer| and "<a for=token/type>`char`</a>".
   1. Run [=add a token with default length=] given |tokenizer|, "<a for=token/type>`end`</a>", |tokenizer|'s [=tokenizer/index=], and |tokenizer|'s [=tokenizer/index=].
   1. Return |tokenizer|'s [=tokenizer/token list=].
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -911,6 +911,7 @@ A [=tokenizer=] has an associated <dfn for=tokenizer>code point</dfn>, a Unicode
         1. Run [=process a tokenizing error=] given |tokenizer|, |name start|, and |tokenizer|'s [=tokenizer/index=].
         1. [=Continue=].
       1. Run [=add a token with default length=] given |tokenizer|, "<a for=token/type>`name`</a>", |name position|, and |name start|.
+      1. [=Continue=].
     1. If |tokenizer|'s [=tokenizer/code point=] is U+0028 (`(`):
       1. Let |depth| be 1.
       1. Let |regexp position| be |tokenizer|'s [=tokenizer/next index=].


### PR DESCRIPTION
This is done in the C++ implementation: https://source.chromium.org/chromium/chromium/src/+/main:third_party/liburlpattern/tokenize.cc;l=110;drc=18869af759673f9a25b6d28ff8f0bfb566f2faa2


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lucacasonato/urlpattern/pull/123.html" title="Last updated on Sep 4, 2021, 3:21 PM UTC (a820316)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/123/7e8cb4c...lucacasonato:a820316.html" title="Last updated on Sep 4, 2021, 3:21 PM UTC (a820316)">Diff</a>