### PR TITLE
Reset the tokenizer next index before tokenizing

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -877,8 +877,7 @@ A [=tokenizer=] has an associated <dfn for=tokenizer>code point</dfn>, a Unicode
   1. Set |tokenizer|'s [=tokenizer/input=] to |input|.
   1. Set |tokenizer|'s [=tokenizer/policy=] to |policy|.
   1. While |tokenizer|'s [=tokenizer/index=] is less than |tokenizer|'s [=tokenizer/input=]'s [=string/code point length=]:
-    1. Set |tokenizer|'s [=tokenizer/next index=] to |tokenizer|'s [=tokenizer/index=].
-    1. Run [=get the next code point=] given |tokenizer|.
+    1. Run [=seek and get the next code point=] given |tokenizer| and |tokenizer|'s [=tokenizer/index=].
     1. If |tokenizer|'s [=tokenizer/code point=] is U+002A (`*`):
       1. Run [=add a token with default position and length=] given |tokenizer| and "<a for=token/type>`asterisk`</a>".
       1. [=Continue=].

--- a/spec.bs
+++ b/spec.bs
@@ -877,6 +877,7 @@ A [=tokenizer=] has an associated <dfn for=tokenizer>code point</dfn>, a Unicode
   1. Set |tokenizer|'s [=tokenizer/input=] to |input|.
   1. Set |tokenizer|'s [=tokenizer/policy=] to |policy|.
   1. While |tokenizer|'s [=tokenizer/index=] is less than |tokenizer|'s [=tokenizer/input=]'s [=string/code point length=]:
+    1. Set |tokenizer|'s [=tokenizer/next index=] to |tokenizer|'s [=tokenizer/index=].
     1. Run [=get the next code point=] given |tokenizer|.
     1. If |tokenizer|'s [=tokenizer/code point=] is U+002A (`*`):
       1. Run [=add a token with default position and length=] given |tokenizer| and "<a for=token/type>`asterisk`</a>".


### PR DESCRIPTION
The Chromium implementation does this via the call to `NextAt` here: https://source.chromium.org/chromium/chromium/src/+/main:third_party/liburlpattern/tokenize.cc;l=56;drc=18869af759673f9a25b6d28ff8f0bfb566f2faa2. `NextAt` resets the "tokenizer's next at" to the passed index here: https://source.chromium.org/chromium/chromium/src/+/main:third_party/liburlpattern/tokenize.cc;l=241;drc=dc64d2ce2bffefb56447b2c17455e7a3b7839eb8?q=urlpattern%20tokenizer&ss=chromium%2Fchromium%2Fsrc.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lucacasonato/urlpattern/pull/124.html" title="Last updated on Sep 7, 2021, 8:18 PM UTC (8f8080e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/124/7e8cb4c...lucacasonato:8f8080e.html" title="Last updated on Sep 7, 2021, 8:18 PM UTC (8f8080e)">Diff</a>