### PR TITLE
Fix constructor string parser `change state` algo

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -658,10 +658,10 @@ To <dfn>parse a constructor string</dfn> given a string |input|:
 </div>
 
 <div algorithm>
-To <dfn>change state</dfn> given a [=constructor string parser=] |parser|, a [=constructor string parser/state=] |state|, and a number |skip|:
+To <dfn>change state</dfn> given a [=constructor string parser=] |parser|, a [=constructor string parser/state=] |new state|, and a number |skip|:
 
-  1. If |state| is not "<a for="constructor string parser/state">`init`</a>", not "<a for="constructor string parser/state">`authority`</a>", and not "<a for="constructor string parser/state">`done`</a>", then set |parser|'s [=constructor string parser/result=][|state|] to the result of running [=make a component string=] given |parser|.
-  1. Set |parser|'s [=constructor string parser/state=] to |state|.
+  1. If |parser|'s [=constructor string parser/state=] is not "<a for="constructor string parser/state">`init`</a>", not "<a for="constructor string parser/state">`authority`</a>", and not "<a for="constructor string parser/state">`done`</a>", then set |parser|'s [=constructor string parser/result=][|parser|'s [=constructor string parser/state=]] to the result of running [=make a component string=] given |parser|.
+  1. Set |parser|'s [=constructor string parser/state=] to |new state|.
   1. Increment |parser|'s [=constructor string parser/token index=] by |skip|.
   1. Set |parser|'s [=constructor string parser/component start=] to |parser|'s [=constructor string parser/token index=].
   1. Set |parser|'s [=constructor string parser/token increment=] to 0.


### PR DESCRIPTION
Previously, the result was set based on "new state", not based on the existing state. This aligns to Chromium implementation: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/url_pattern/url_pattern_parser.cc;l=271-275;drc=7bd7edac514e6a13820d9982afaa8a5102bd7688


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lucacasonato/urlpattern/pull/129.html" title="Last updated on Sep 6, 2021, 2:44 PM UTC (5ac6eea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/129/7e8cb4c...lucacasonato:5ac6eea.html" title="Last updated on Sep 6, 2021, 2:44 PM UTC (5ac6eea)">Diff</a>