### PR TITLE
Use exclusive substring in make component string

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -800,7 +800,8 @@ To run <dfn>make a component string</dfn> given a [=constructor string parser=] 
   1. Let |token| be |parser|'s [=constructor string parser/token list=][|parser|'s [=constructor string parser/token index=]].
   1. Let |component start token| be the result of running [=get a safe token=] given |parser| and |parser|'s [=constructor string parser/component start=].
   1. Let |component start input index| be |component start token|'s [=token/index=].
-  1. Return the [=code point substring by indices|code point substring=] from indices |component start input index| to |token|'s [=token/index=] exclusive within |parser|'s [=constructor string parser/input=].
+  1. Let |end index| be |token|'s [=token/index=] - 1.
+  1. Return the [=code point substring by indices|code point substring=] from indices |component start input index| to |end index| inclusive within |parser|'s [=constructor string parser/input=].
 </div>
 
 <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -800,7 +800,7 @@ To run <dfn>make a component string</dfn> given a [=constructor string parser=] 
   1. Let |token| be |parser|'s [=constructor string parser/token list=][|parser|'s [=constructor string parser/token index=]].
   1. Let |component start token| be the result of running [=get a safe token=] given |parser| and |parser|'s [=constructor string parser/component start=].
   1. Let |component start input index| be |component start token|'s [=token/index=].
-  1. Return the [=code point substring by indices|code point substring=] from indices |component start input index| to |token|'s [=token/index=] inclusive within |parser|'s [=constructor string parser/input=].
+  1. Return the [=code point substring by indices|code point substring=] from indices |component start input index| to |token|'s [=token/index=] exclusive within |parser|'s [=constructor string parser/input=].
 </div>
 
 <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -800,7 +800,7 @@ To run <dfn>make a component string</dfn> given a [=constructor string parser=] 
   1. Let |token| be |parser|'s [=constructor string parser/token list=][|parser|'s [=constructor string parser/token index=]].
   1. Let |component start token| be the result of running [=get a safe token=] given |parser| and |parser|'s [=constructor string parser/component start=].
   1. Let |component start input index| be |component start token|'s [=token/index=].
-  1. Let |end index| be |token|'s [=token/index=] - 1.
+  1. Let |end index| be |token|'s [=token/index=] &minus; 1.
   1. Return the [=code point substring by indices|code point substring=] from indices |component start input index| to |end index| inclusive within |parser|'s [=constructor string parser/input=].
 </div>
 


### PR DESCRIPTION
Chromium implementation uses an exclusive substring: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/url_pattern/url_pattern_parser.cc;l=454-455;drc=7bd7edac514e6a13820d9982afaa8a5102bd7688


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lucacasonato/urlpattern/pull/130.html" title="Last updated on Sep 7, 2021, 8:16 PM UTC (e8e6623)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/130/7e8cb4c...lucacasonato:e8e6623.html" title="Last updated on Sep 7, 2021, 8:16 PM UTC (e8e6623)">Diff</a>