### PR TITLE
Handle no baseURL + relative input failure case

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -270,6 +270,7 @@ Each {{URLPattern}} object has an associated <dfn for=URLPattern>hash component<
   1. Let |init| be null.
   1. If |input| is a [=scalar value string=] then:
     1. Set |init| to the result of running [=parse a constructor string=] given |input|.
+    1. If |baseURL| is not given and |init|["{{URLPatternInit/protocol}}"] is null, then throw a {{TypeError}}.
     1. Set |init|["{{URLPatternInit/baseURL}}"] to |baseURL|.
   1. Else:
     1. [=Assert=]: |input| is a {{URLPatternInit}}.


### PR DESCRIPTION
If the passed input to the URLPattern constructor is a relative path,
and no baseURL is set, throw a TypeError.

This behaviour aligns with Chromium implementation and tests: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/url_pattern/url_pattern.cc;l=213-219;drc=7bd7edac514e6a13820d9982afaa8a5102bd7688
