### PR TITLE
Add missing "continue" in pattern parser

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1170,6 +1170,7 @@ To <dfn>parse a pattern string</dfn> given a [=/pattern string=] |input|, [=/opt
       1. Run [=consume a required token=] given |parser| and "<a for=token/type>`close`</a>".
       1. Set |modifier token| to the result of running [=try to consume a modifier token=] given |parser|.
       1. Run [=add a part=] given |parser|, |prefix|, |name token|, |regexp or wildcard token|, |suffix|, and |modifier token|.
+      1. [=Continue=].
     1. Run [=maybe add a part from the pending fixed value=] given |parser|.
     1. Run [=consume a required token=] given |parser| and "<a for=token/type>`end`</a>".
   1. Return |parser|'s [=pattern parser/part list=].


### PR DESCRIPTION
Chromium implementation has this "continue":
https://source.chromium.org/chromium/chromium/src/+/main:third_party/liburlpattern/parse.cc;l=397;drc=ac3b649031d4c82cb66e26144551e2b38363065b


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lucacasonato/urlpattern/pull/132.html" title="Last updated on Sep 6, 2021, 4:43 PM UTC (dcbb8a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/132/7e8cb4c...lucacasonato:dcbb8a0.html" title="Last updated on Sep 6, 2021, 4:43 PM UTC (dcbb8a0)">Diff</a>