### PR TITLE
Use standard pathname canonicalization when the protocol is the empty…

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1719,7 +1719,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>process pathname for init</dfn> given a string |pathnameValue|, a string |protocolValue|, and a string |type|:
 
   1. If |type| is "`pattern`" then return |pathnameValue|.
-  1. If |protocolValue| is a [=special scheme=], then return the result of running [=canonicalize a pathname=] given |pathnameValue|.
+  1. If |protocolValue| is a [=special scheme=] or the empty string, then return the result of running [=canonicalize a pathname=] given |pathnameValue|.
+    <p class=note>If the |protocolValue| is the empty string then no value was provided for {{URLPatternInit/protocol}} in the constructor dictionary.  Normally we do not special case empty string dictionary values, but in this case we treat it as a [=special scheme=] in order to default to the most common pathname canonicalization.
   1. Else return the result of running [=canonicalize a cannot-be-a-base-URL pathname=] given |pathnameValue|.
 </div algorithm>
 


### PR DESCRIPTION
… string. (Fixes #122)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/136.html" title="Last updated on Sep 8, 2021, 9:10 PM UTC (ee17c45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/136/ae656a4...ee17c45.html" title="Last updated on Sep 8, 2021, 9:10 PM UTC (ee17c45)">Diff</a>