### PR TITLE
Don't emit '*' when it can be confused for a modifier. (#145)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1421,7 +1421,10 @@ To <dfn>escape a regexp string</dfn> given a string |input|:
 To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] |part list| and [=/options=] |options|:
 
   1. Let |result| be the empty string.
-  1. [=list/For each=] |part| of |part list|:
+  1. Let |index list| be the result of [=list/getting the indices=] for |part list|.
+  1. [=list/For each=] |index| of |index list|:
+    1. Let |part| be |part list|[|index|].
+    1. Let |last part| be |part list|[|index| - 1] if |index| is greater than 0, otherwise let it be null.
     1. If |part|'s [=part/type=] is "<a for=part/type>`fixed-text`</a>" then:
       1. If |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>" then:
         1. Append the result of running [=escape a pattern string=] given |part|'s [=part/value=] to the end of |result|.
@@ -1452,7 +1455,12 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
       1. Append the result of running [=generate a segment wildcard regexp=] given |options| to the end of |result|.
       1. Append "`)`" to the end of |result|.
     1. Else if |part|'s [=part/type=] is "<a for=part/type>`full-wildcard`</a>":
-      1. If |custom name| is true:
+      1. If one of the following are true:
+        <ul>
+          <li>|custom name| is true.</li>
+          <li>|last part| is not null, |last part|'s [=part/type=] is not "<a for=part/type>`fixed-text`</a>", and |last part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>".
+        </ul>
+        Then:
         1. Append "`(`" to the end of |result|.
         1. Append [=full wildcard regexp value=] to the end of |result|.
         1. Append "`)`" to the end of |result|.

--- a/spec.bs
+++ b/spec.bs
@@ -1424,7 +1424,8 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
   1. Let |index list| be the result of [=list/getting the indices=] for |part list|.
   1. [=list/For each=] |index| of |index list|:
     1. Let |part| be |part list|[|index|].
-    1. Let |last part| be |part list|[|index| - 1] if |index| is greater than 0, otherwise let it be null.
+    1. Let |previous part| be |part list|[|index| - 1] if |index| is greater than 0, otherwise let it be null.
+    1. Let |next part| be |part list|[|index| + 1] if |index| is less than |index list|'s [=list/size] - 1, otherwise let it be null.
     1. If |part|'s [=part/type=] is "<a for=part/type>`fixed-text`</a>" then:
       1. If |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>" then:
         1. Append the result of running [=escape a pattern string=] given |part|'s [=part/value=] to the end of |result|.
@@ -1434,13 +1435,14 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
       1. Append "`}`" to the end of |result|.
       1. Append the result of running [=convert a modifier to a string=] given |part|'s [=part/modifier=] to the end of |result|.
       1. [=Continue=].
+    1. Let |custom name| be true if |part|'s [=part/name=][0] is not an [=ASCII digit=]; otherwise false.
     1. Let |needs grouping| be true if at least one of the following are true, otherwise let it be false:
       <ul>
         <li>|part|'s [=part/suffix=] is not the empty string.</li>
-        <li>|part|'s [=part/prefix=] is not the empty string and is not |options|'s [=options/prefix code point=].
+        <li>|part|'s [=part/prefix=] is not the empty string and is not |options|'s [=options/prefix code point=].</li>
+        <li>|custom name| is true, |part|'s [=part/type=] is "<a for=part/type>`segment-wildcard`</a>", |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>", |next part| is not null, |next part|'s [=part/type=] is not "<a for=part/type>`fixed-text`</a>", |next part|'s [=part/prefix=] is the empty string, |next part|'s [=part/suffix=] is the empty string, and |next part|'s [=part/name=][0] is an [=ASCII digit=].
       </ul>
     1. [=Assert=]: |part|'s [=part/name=] is not the empty string or null.
-    1. Let |custom name| be true if |part|'s [=part/name=][0] is not an [=ASCII digit=].
     1. If |needs grouping| is true, then append "`{`" to the end of |result|.
     1. Append the result of running [=escape a pattern string=] given |part|'s [=part/prefix=] to the end of |result|.
     1. If |custom name| is true:
@@ -1455,12 +1457,12 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
       1. Append the result of running [=generate a segment wildcard regexp=] given |options| to the end of |result|.
       1. Append "`)`" to the end of |result|.
     1. Else if |part|'s [=part/type=] is "<a for=part/type>`full-wildcard`</a>":
-      1. If one of the following are true:
+      1. If one of the following is true:
         <ul>
-          <li>|custom name| is true.</li>
-          <li>|last part| is not null, |last part|'s [=part/type=] is not "<a for=part/type>`fixed-text`</a>", and |last part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>".
+          <li>|custom name| is true; or</li>
+          <li>|previous part| is not null, |previous part|'s [=part/type=] is not "<a for=part/type>`fixed-text`</a>", and |previous part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>"
         </ul>
-        Then:
+        then:
         1. Append "`(`" to the end of |result|.
         1. Append [=full wildcard regexp value=] to the end of |result|.
         1. Append "`)`" to the end of |result|.


### PR DESCRIPTION
This fixes one of the cases outlined in #145.  When we have a matching group
following by a wildcard we must be careful not to emit `*` for the wildcard.
We don't want it to be mistaken for modifier on the previous group.  So we
want to generate `(foo)(.*)` and not `(foo)*`.

This change corresponds to this implementation change in chromium:

https://chromium-review.googlesource.com/c/chromium/src/+/3313642


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/151.html" title="Last updated on Dec 9, 2021, 9:10 PM UTC (6f57c26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/151/dbb9521...6f57c26.html" title="Last updated on Dec 9, 2021, 9:10 PM UTC (6f57c26)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/151.html" title="Last updated on Jan 5, 2022, 4:26 PM UTC (611d26f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/151/dbb9521...611d26f.html" title="Last updated on Jan 5, 2022, 4:26 PM UTC (611d26f)">Diff</a>