### PR TITLE
Emit `{}` around custom names followed by a regexp group. (#145)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1425,7 +1425,7 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
   1. [=list/For each=] |index| of |index list|:
     1. Let |part| be |part list|[|index|].
     1. Let |last part| be |part list|[|index| - 1] if |index| is greater than 0, otherwise let it be null.
-    1. Let |next part| be |part list|[|index| + 1] if |index| is less than |index list|'s [=list/size] = 1, otherwise let it be null.
+    1. Let |next part| be |part list|[|index| + 1] if |index| is less than |index list|'s [=list/size] - 1, otherwise let it be null.
     1. If |part|'s [=part/type=] is "<a for=part/type>`fixed-text`</a>" then:
       1. If |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>" then:
         1. Append the result of running [=escape a pattern string=] given |part|'s [=part/value=] to the end of |result|.
@@ -1435,7 +1435,7 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
       1. Append "`}`" to the end of |result|.
       1. Append the result of running [=convert a modifier to a string=] given |part|'s [=part/modifier=] to the end of |result|.
       1. [=Continue=].
-    1. Let |custom name| be true if |part|'s [=part/name=][0] is not an [=ASCII digit=].
+    1. Let |custom name| be true if |part|'s [=part/name=][0] is not an [=ASCII digit=]; otherwise false.
     1. Let |needs grouping| be true if at least one of the following are true, otherwise let it be false:
       <ul>
         <li>|part|'s [=part/suffix=] is not the empty string.</li>

--- a/spec.bs
+++ b/spec.bs
@@ -1425,6 +1425,7 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
   1. [=list/For each=] |index| of |index list|:
     1. Let |part| be |part list|[|index|].
     1. Let |last part| be |part list|[|index| - 1] if |index| is greater than 0, otherwise let it be null.
+    1. Let |next part| be |part list|[|index| + 1] if |index| is less than |index list|'s [=list/size] = 1, otherwise let it be null.
     1. If |part|'s [=part/type=] is "<a for=part/type>`fixed-text`</a>" then:
       1. If |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>" then:
         1. Append the result of running [=escape a pattern string=] given |part|'s [=part/value=] to the end of |result|.
@@ -1434,13 +1435,14 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
       1. Append "`}`" to the end of |result|.
       1. Append the result of running [=convert a modifier to a string=] given |part|'s [=part/modifier=] to the end of |result|.
       1. [=Continue=].
+    1. Let |custom name| be true if |part|'s [=part/name=][0] is not an [=ASCII digit=].
     1. Let |needs grouping| be true if at least one of the following are true, otherwise let it be false:
       <ul>
         <li>|part|'s [=part/suffix=] is not the empty string.</li>
-        <li>|part|'s [=part/prefix=] is not the empty string and is not |options|'s [=options/prefix code point=].
+        <li>|part|'s [=part/prefix=] is not the empty string and is not |options|'s [=options/prefix code point=].</li>
+        <li>|custom name| is true, |part|'s [=part/type=] is "<a for=part/type>`segment-wildcard`</a>", |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>", |next part| is not null, |next part|'s [=part/type=] is not "<a for=part/type>`fixed-text`</a>", |next part|'s [=part/prefix=] is the empty string, |next part|'s [=part/suffix=] is the empty string, and |next part|'s [=part/name=][0] is an [=ASCII digit=].
       </ul>
     1. [=Assert=]: |part|'s [=part/name=] is not the empty string or null.
-    1. Let |custom name| be true if |part|'s [=part/name=][0] is not an [=ASCII digit=].
     1. If |needs grouping| is true, then append "`{`" to the end of |result|.
     1. Append the result of running [=escape a pattern string=] given |part|'s [=part/prefix=] to the end of |result|.
     1. If |custom name| is true:


### PR DESCRIPTION
This change fixes another case from #145.  Here we need protect a `:foo`
group with `{}` braces if its followed by a matching group that may be
expressed as `(bar)`.  Without this protection the second group may be
interpreted as a custom regexp for the first group.  We want to generate
`{:foo}(bar)` and not `:foo(bar)`.

For the most part this change corresponds to this chromium commit:

https://chromium-review.googlesource.com/c/chromium/src/+/3315419

Note, however, this spec change includes an additional fix to check for
the next part being a segment wildcard.  That additional check will need
to be added to the implementation in another change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/152.html" title="Last updated on Dec 9, 2021, 10:06 PM UTC (561f6cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/152/6f57c26...561f6cf.html" title="Last updated on Dec 9, 2021, 10:06 PM UTC (561f6cf)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/152.html" title="Last updated on Jan 5, 2022, 3:50 PM UTC (101f35c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/152/6f57c26...101f35c.html" title="Last updated on Jan 5, 2022, 3:50 PM UTC (101f35c)">Diff</a>