### PR TITLE
Escape some suffixes trailing `:foo` groups. (#145)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1467,6 +1467,14 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
         1. Append [=full wildcard regexp value=] to the end of |result|.
         1. Append "`)`" to the end of |result|.
       1. Else append "`*`" to the end of |result|.
+    1. If all of the following are true:
+      <ul>
+        <li>|part|'s [=part/type=] is "<a for=part/type>`segment-wildcard`</a>"; and</li>
+        <li>|custom name| is true; and</li>
+        <li>|part|'s [=part/suffix=] is not the empty string; and</li>
+        <li>The result of running [=is a valid name code point=] given |part|'s [=part/suffix=]'s first [=/code point=] and the boolean false is true</li>
+      </ul>
+      then append U+005C (<code>\</code>) to the end of |result|.
     1. Append the result of running [=escape a pattern string=] given |part|'s [=part/suffix=] to the end of |result|.
     1. If |needs grouping| is true, then append "`}`" to the end of |result|.
     1. Append the result of running [=convert a modifier to a string=] given |part|'s [=part/modifier=] to the end of |result|.


### PR DESCRIPTION
This fixes one of the cases outlined in #145.  When a named group, like
`:foo`, has a suffix that begins with a valid name character, like `bar`,
we run the risk of generating a string that adds the suffix to the name
itself and not as a suffix to the group.  To avoid this we insert an
escape character before the suffix.  For example, we want to generate
`:foo\bar` and not `:foobar`.

This spec change corresponds to this implementation change:

https://chromium-review.googlesource.com/c/chromium/src/+/3318605


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/153.html" title="Last updated on Jan 6, 2022, 2:59 PM UTC (cbd5dfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/153/3c8a799...cbd5dfa.html" title="Last updated on Jan 6, 2022, 2:59 PM UTC (cbd5dfa)">Diff</a>