### PR TITLE
Emit `{}` when plain text follows a `:foo` group. (#145)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1453,7 +1453,7 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
       </ul>
       then:
       1. If |next part|'s [=part/type=] is "<a for=part/type>`fixed-text`</a>":
-        1. Set |needs grouping| to true if the result of running [=is a valid name code point=] given |next part|'s [=part/value=]'s first [=/code point=] and then boolean false is true.
+        1. Set |needs grouping| to true if the result of running [=is a valid name code point=] given |next part|'s [=part/value=]'s first [=/code point=] and the boolean false is true.
       1. Else:
         1. Set |needs grouping| to true if |next part|'s [=part/name=][0] is an [=ASCII digit=].
     1. [=Assert=]: |part|'s [=part/name=] is not the empty string or null.

--- a/spec.bs
+++ b/spec.bs
@@ -1425,7 +1425,7 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
   1. [=list/For each=] |index| of |index list|:
     1. Let |part| be |part list|[|index|].
     1. Let |previous part| be |part list|[|index| - 1] if |index| is greater than 0, otherwise let it be null.
-    1. Let |next part| be |part list|[|index| + 1] if |index| is less than |index list|'s [=list/size] - 1, otherwise let it be null.
+    1. Let |next part| be |part list|[|index| + 1] if |index| is less than |index list|'s [=list/size=] - 1, otherwise let it be null.
     1. If |part|'s [=part/type=] is "<a for=part/type>`fixed-text`</a>" then:
       1. If |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>" then:
         1. Append the result of running [=escape a pattern string=] given |part|'s [=part/value=] to the end of |result|.
@@ -1440,8 +1440,22 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
       <ul>
         <li>|part|'s [=part/suffix=] is not the empty string.</li>
         <li>|part|'s [=part/prefix=] is not the empty string and is not |options|'s [=options/prefix code point=].</li>
-        <li>|custom name| is true, |part|'s [=part/type=] is "<a for=part/type>`segment-wildcard`</a>", |part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>", |next part| is not null, |next part|'s [=part/type=] is not "<a for=part/type>`fixed-text`</a>", |next part|'s [=part/prefix=] is the empty string, |next part|'s [=part/suffix=] is the empty string, and |next part|'s [=part/name=][0] is an [=ASCII digit=].
       </ul>
+    1. If all of the following are true:
+      <ul>
+        <li>|needs grouping| is false; and</li>
+        <li>|custom name| is true; and</li>
+        <li>|part|'s [=part/type=] is "<a for=part/type>`segment-wildcard`</a>"; and</li>
+        <li>|part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>"; and</li>
+        <li>|next part| is not null; and</li>
+        <li>|next part|'s [=part/prefix=] is the empty string; and</li>
+        <li>|next part|'s [=part/suffix=] is the empty string</li>
+      </ul>
+      then:
+      1. If |next part|'s [=part/type=] is "<a for=part/type>`fixed-text`</a>":
+        1. Set |needs grouping| to true if the result of running [=is a valid name code point=] given |next part|'s [=part/value=]'s first [=/code point=] and then boolean false is true.
+      1. Else:
+        1. Set |needs grouping| to true if |next part|'s [=part/name=][0] is an [=ASCII digit=].
     1. [=Assert=]: |part|'s [=part/name=] is not the empty string or null.
     1. If |needs grouping| is true, then append "`{`" to the end of |result|.
     1. Append the result of running [=escape a pattern string=] given |part|'s [=part/prefix=] to the end of |result|.


### PR DESCRIPTION
This fixes another issue highlighted in #145.

In this case we need to detect when fixed text following a `:foo` group
could be mistaken as part of the name.  When this happens we should emit
`{ }` braces around the group to isolate it.  For example, `{:foo}bar`
instead of of `:foobar`.

This spec change corresponds to the following implementation changes:

https://chromium-review.googlesource.com/c/chromium/src/+/3321520
https://chromium-review.googlesource.com/c/chromium/src/+/3328146


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/154.html" title="Last updated on Jan 6, 2022, 8:52 PM UTC (c82253b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/154/8e6e605...c82253b.html" title="Last updated on Jan 6, 2022, 8:52 PM UTC (c82253b)">Diff</a>