### PR TITLE
Fix pathname encoding for isolated '.' and '..' values. (#156)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1618,7 +1618,13 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
 <div algorithm>
   To <dfn>canonicalize a pathname</dfn> given a string |value|:
 
-  1. If |value| is the empty string, return |value|.
+  1. If |value| is one of the following:
+    <ul>
+      <li>the empty string; or</li>
+      <li>"`.`"; or</li>
+      <li>"`..`"
+    </ul>
+    then return |value|.
   1. Let |dummyURL| be a new [=URL record=].
   1. Let |parseResult| be the result of running [=basic URL parser=] given |value| with |dummyURL| as </i>[=basic URL parser/url=]</i> and [=path start state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.


### PR DESCRIPTION
This commit fixes an issue where '.' and '..' could be incorrectly
removed from a pathname during parsing.  This would happen in cases
where the encoding callback saw the '.' or '..' individually without
surrounding characters.  This would cause the algorithm to encode
them as '/.' or '/..' which the URL parser collapses to just '/'.

To avoid this behavior we explicitly check for '.' and '..' values
so they can be immediately returned without encoding.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/157.html" title="Last updated on Jan 18, 2022, 8:20 PM UTC (defa04d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/157/7336960...defa04d.html" title="Last updated on Jan 18, 2022, 8:20 PM UTC (defa04d)">Diff</a>