### PR TITLE
Remove erroneous prefix check when generating string. (#145)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1444,7 +1444,6 @@ To <dfn export>generate a [=/pattern string=]</dfn> from a given [=/part list=] 
     1. If all of the following are true:
       <ul>
         <li>|needs grouping| is false; and</li>
-        <li>|part|'s [=part/prefix=] is the empty string; and</li>
         <li>|custom name| is true; and</li>
         <li>|part|'s [=part/type=] is "<a for=part/type>`segment-wildcard`</a>"; and</li>
         <li>|part|'s [=part/modifier=] is "<a for=part/modifier>`none`</a>"; and</li>


### PR DESCRIPTION
This fixes another issue with generating canonical pattern strings as described
in #145.  In this case the prefix check incorrectly prevented us from
protecting a named group from following character if there was an implicit
prefix.  For example, for a pathname `/:foo\\bar` we would incorrectly produce
`/:foobar` instead of `{/:foo}bar`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/161.html" title="Last updated on Jan 20, 2022, 9:48 PM UTC (94a8b7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/161/f4bffc6...94a8b7b.html" title="Last updated on Jan 20, 2022, 9:48 PM UTC (94a8b7b)">Diff</a>