### PR TITLE
Update webidl to allow matched group values to be undefined. (#162)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -163,7 +163,7 @@ dictionary URLPatternResult {
 
 dictionary URLPatternComponentResult {
   USVString input;
-  record<USVString, USVString> groups;
+  record<USVString, (USVString or undefined)> groups;
 };
 </xmp>
 
@@ -438,7 +438,7 @@ A [=component=] has an associated <dfn for=component>group name list</dfn>, a [=
 
   1. Let |result| be a new {{URLPatternComponentResult}}.
   1. Set |result|["{{URLPatternComponentResult/input}}"] to |input|.
-  1. Let |groups| be a <code>[=record=]<{{USVString}}, {{USVString}}></code>.
+  1. Let |groups| be a <code>[=record=]<{{USVString}}, ({{USVString}} or {{undefined}})></code>.
   1. Let |index| be 1.
   1. While |index| is less than [$Get$](|execResult|, "`length`"):
     1. Let |name| be |component|'s [=component/group name list=][|index| &minus; 1].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/164.html" title="Last updated on Feb 2, 2022, 9:27 PM UTC (d4fb593)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/164/276ef33...d4fb593.html" title="Last updated on Feb 2, 2022, 9:27 PM UTC (d4fb593)">Diff</a>