### PR TITLE
Increment |index| in loop properly.  (Fixes #173)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -479,6 +479,7 @@ A [=component=] has an associated <dfn for=component>group name list</dfn>, a [=
     1. Let |name| be |component|'s [=component/group name list=][|index| &minus; 1].
     1. Let |value| be [$Get$](|execResult|, [$ToString$](|index|)).
     1. Set |groups|[|name|] to |value|.
+    1. Increment |index| by 1.
   1. Set |result|["{{URLPatternComponentResult/groups}}"] to |groups|.
   1. Return |result|.
 </div>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/174.html" title="Last updated on Nov 21, 2022, 5:23 PM UTC (a404150)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/174/4e670f9...a404150.html" title="Last updated on Nov 21, 2022, 5:23 PM UTC (a404150)">Diff</a>