### PR TITLE
Meta: Remove private parser states

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -36,16 +36,6 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: IdentifierStart; url: #prod-IdentifierStart
   type: interface
     text: RegExp; url: #sec-regexp-regular-expression-objects
-spec: url; urlPrefix: https://url.spec.whatwg.org/
-  type: dfn
-    text: default port; url: #default-port
-    text: fragment state; url: #fragment-state
-    text: hostname state; url: #hostname-state
-    text: path start state; url: #path-start-state
-    text: port state; url: #port-state
-    text: query state; url: #query-state
-    text: special scheme; url: #special-scheme
-    text: scheme start state; url: #scheme-start-state
 </pre>
 
 <style>


### PR DESCRIPTION
Meta: Remove private parser states

This PR removes private states from anchors.
This doesn't make any visible changes.

Fixes #141.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/185.html" title="Last updated on Sep 12, 2023, 4:05 PM UTC (b12374c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/185/640b0ed...b12374c.html" title="Last updated on Sep 12, 2023, 4:05 PM UTC (b12374c)">Diff</a>