### PR TITLE
Meta: remove some more unnecessary anchors

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -26,16 +26,9 @@ spec:webidl; type:dfn; text:record
 
 <pre class="anchors">
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
-  type: abstract-op
-    text: Get; url: #sec-get-o-p
-    text: RegExpBuiltinExec; url: #sec-regexpbuiltinexec
-    text: RegExpCreate; url: #sec-regexpcreate
-    text: ToString; url: #sec-tostring
   type: dfn
     text: IdentifierPart; url: #prod-IdentifierPart
     text: IdentifierStart; url: #prod-IdentifierStart
-  type: interface
-    text: RegExp; url: #sec-regexp-regular-expression-objects
 </pre>
 
 <style>


### PR DESCRIPTION
Recent Bikeshed updates use a database which contains most (but not all) ECMAScript terms, so we can avoid the need to include them in the anchors block.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/186.html" title="Last updated on Sep 12, 2023, 4:20 PM UTC (6fa542a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/186/12b1553...6fa542a.html" title="Last updated on Sep 12, 2023, 4:20 PM UTC (6fa542a)">Diff</a>