### PR TITLE
Expand introductory text and examples

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -878,11 +878,11 @@ A <dfn>pattern string</dfn> is a string that is written to match a set of target
 It can be [=parse a pattern string|parsed=] to produce a [=/part list=] which describes, in order, what must appear in a component string for the pattern string to match.
 
 <div class="example">
-  Pattern strings can contain capture groups, which by default match the shortest possible string, up to a component-specific separator (`/` in the pathname, `.` in the hostname). For example, the pathname pattern "`/blog/:title`" will match "`/blog/hello-world`" but not "`/blog/2012/02"`.
+  Pattern strings can contain capture groups, which by default match the shortest possible string, up to a component-specific separator (`/` in the pathname, `.` in the hostname). For example, the pathname pattern "`/blog/:title`" will match "`/blog/hello-world`" but not "`/blog/2012/02`".
 
   A regular expression can also be used instead, so the pathname pattern "`/blog/:year(\\d+)/:month(\\d+)`" will match "`/blog/2012/02`".
 
-  A group can also be made optional, or repeated, by using a modifier. For example, the pathname pattern "`/products/:id?"` will match both "`/products`" and "`/products/2`" (but not "`/products/`"). In the pathname specifically, groups automatically require a leading `/`; to avoid this, the group can be explicitly deliminated, as in the pathname pattern "`/products/{:id}?"`.
+  A group can also be made optional, or repeated, by using a modifier. For example, the pathname pattern "`/products/:id?"` will match both "`/products`" and "`/products/2`" (but not "`/products/`"). In the pathname specifically, groups automatically require a leading `/`; to avoid this, the group can be explicitly deliminated, as in the pathname pattern "`/products/{:id}?`".
 
   A full wildcard `*` can also be used to match as much as possible, as in the pathname pattern "`/products/*`".
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -104,7 +104,7 @@ p + dl.props { margin-top: -0.5em; }
 
 <h2 id=urlpattern-class>The {{URLPattern}} class </h2>
 
-A {{URLPattern}} consists of several [=components=], each of which represents a [=pattern string|pattern=] which could be matched against the corresponding component of a [=URL=].
+A {{URLPattern}} consists of several [=components=], each of which represents a [=/pattern string|pattern=] which could be matched against the corresponding component of a [=/URL=].
 
 It can be constructed using a string for each component, or from a shorthand string. It can optionally be resolved relative to a base URL.
 
@@ -875,7 +875,7 @@ To <dfn>compute protocol matches a special scheme flag</dfn> given a [=construct
 
 A <dfn>pattern string</dfn> is a string that is written to match a set of target strings.  A <dfn for="pattern string">well formed</dfn> pattern string conforms to a particular pattern syntax.  This pattern syntax is directly based on the syntax used by the popular [path-to-regexp](https://github.com/pillarjs/path-to-regexp) JavaScript library.
 
-It can be [=parse a pattern string|parsed=] to produce a [=part list=] which describes, in order, what must appear in a component string for the pattern string to match.
+It can be [=parse a pattern string|parsed=] to produce a [=/part list=] which describes, in order, what must appear in a component string for the pattern string to match.
 
 <div class="example">
   Pattern strings can contain capture groups, which by default match the shortest possible string, up to a component-specific separator (`/` in the pathname, `.` in the hostname). For example, the pathname pattern "`/blog/:title`" will match "`/blog/hello-world`" but not "`/blog/2012/02"`.

--- a/spec.bs
+++ b/spec.bs
@@ -92,11 +92,53 @@ table {
   top: -0.8em;
   left: -0.8em;
 }
+
+/* props from https://resources.whatwg.org/standard.css */
+dl.props { display: grid; grid-template-columns: max-content auto; row-gap: 0.25em; column-gap: 1em; }
+dl.props > dt { grid-column-start: 1; margin: 0; }
+dl.props > dd { grid-column-start: 2; margin: 0; }
+p + dl.props { margin-top: -0.5em; }
 </style>
 
 <script src="https://resources.whatwg.org/file-issue.js" async></script>
 
 <h2 id=urlpattern-class>The {{URLPattern}} class </h2>
+
+A {{URLPattern}} consists of several [=components=], each of which represents a [=pattern string|pattern=] which could be matched against the corresponding component of a [=URL=].
+
+It can be constructed using a string for each component, or from a shorthand string. It can optionally be resolved relative to a base URL.
+
+<div class="example">
+  The shorthand "`https://example.com/:category/*`" corresponds to the following components:
+
+  <dl class="props">
+    :  [=protocol component|protocol=]
+    :: "`https`"
+    :  [=username component|username=]
+    :: ""
+    :  [=password component|password=]
+    :: ""
+    :  [=hostname component|hostname=]
+    :: "`example.com`"
+    :  [=port component|port=]
+    :: ""
+    :  [=pathname component|pathname=]
+    :: "`/:category/*`"
+    :  [=search component|search=]
+    :: ""
+    :  [=hash component|hash=]
+    :: ""
+  </dl>
+
+  It matches the following URLs:
+  * `https://example.com/products/`
+  * `https://example.com/blog/our-greatest-product-ever`
+
+  It does not match the following URLs:
+  * `https://example.com/`
+  * `http://example.com/products/`
+  * `https://example.com:8443/blog/our-greatest-product-ever`
+</div>
 
 <xmp class="idl">
 typedef (USVString or URLPatternInit) URLPatternInput;
@@ -832,6 +874,18 @@ To <dfn>compute protocol matches a special scheme flag</dfn> given a [=construct
 <h2 id=patterns>Patterns</h2>
 
 A <dfn>pattern string</dfn> is a string that is written to match a set of target strings.  A <dfn for="pattern string">well formed</dfn> pattern string conforms to a particular pattern syntax.  This pattern syntax is directly based on the syntax used by the popular [path-to-regexp](https://github.com/pillarjs/path-to-regexp) JavaScript library.
+
+It can be [=parse a pattern string|parsed=] to produce a [=part list=] which describes, in order, what must appear in a component string for the pattern string to match.
+
+<div class="example">
+  Pattern strings can contain capture groups, which by default match the shortest possible string, up to a component-specific separator (`/` in the pathname, `.` in the hostname). For example, the pathname pattern "`/blog/:title`" will match "`/blog/hello-world`" but not "`/blog/2012/02"`.
+
+  A regular expression can also be used instead, so the pathname pattern "`/blog/:year(\\d+)/:month(\\d+)`" will match "`/blog/2012/02`".
+
+  A group can also be made optional, or repeated, by using a modifier. For example, the pathname pattern "`/products/:id?"` will match both "`/products`" and "`/products/2`" (but not "`/products/`"). In the pathname specifically, groups automatically require a leading `/`; to avoid this, the group can be explicitly deliminated, as in the pathname pattern "`/products/{:id}?"`.
+
+  A full wildcard `*` can also be used to match as much as possible, as in the pathname pattern "`/products/*`".
+</div>
 
 <h3 id=parsing-patterns>Parsing Patterns</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -112,21 +112,21 @@ It can be constructed using a string for each component, or from a shorthand str
   The shorthand "`https://example.com/:category/*`" corresponds to the following components:
 
   <dl class="props">
-    :  [=protocol component|protocol=]
+    :  [=URLPattern/protocol component|protocol=]
     :: "`https`"
-    :  [=username component|username=]
+    :  [=URLPattern/username component|username=]
     :: ""
-    :  [=password component|password=]
+    :  [=URLPattern/password component|password=]
     :: ""
-    :  [=hostname component|hostname=]
+    :  [=URLPattern/hostname component|hostname=]
     :: "`example.com`"
-    :  [=port component|port=]
+    :  [=URLPattern/port component|port=]
     :: ""
-    :  [=pathname component|pathname=]
+    :  [=URLPattern/pathname component|pathname=]
     :: "`/:category/*`"
-    :  [=search component|search=]
+    :  [=URLPattern/search component|search=]
     :: ""
-    :  [=hash component|hash=]
+    :  [=URLPattern/hash component|hash=]
     :: ""
   </dl>
 


### PR DESCRIPTION
Some simple introductory examples are added, along with some brief
overview text of both URL patterns and (component-specific) pattern
strings.

Some more detailed examples already exist within the relevant parsing
code.

This contributes to resolving #127.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/urlpattern/pull/187.html" title="Last updated on Sep 13, 2023, 1:30 PM UTC (1f066e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/187/80af74a...jeremyroman:1f066e3.html" title="Last updated on Sep 13, 2023, 1:30 PM UTC (1f066e3)">Diff</a>