### PR TITLE
Updates the regular expression to work with the `v` flag instead of `u`

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -423,8 +423,8 @@ A [=component=] has an associated <dfn for=component>group name list</dfn>, a [=
   1. Let |part list| be the result of running [=parse a pattern string=] given |input|, |options|, and |encoding callback|.
   1. Let (|regular expression string|, |name list|) be the result of running [=generate a regular expression and name list=] given |part list| and |options|.
   1. Let |flags| be an empty string.
-  1. If |options|'s [=options/ignore case=] is true then set |flags| to "`ui`".
-  1. Otherwise set |flags| to "`u`"
+  1. If |options|'s [=options/ignore case=] is true then set |flags| to "`vi`".
+  1. Otherwise set |flags| to "`v`"
   1. Let |regular expression| be [$RegExpCreate$](|regular expression string|, |flags|).  If this throws an exception, catch it, and throw a {{TypeError}}.
     <p class="note allow-2119">The specification uses regular expressions to perform all matching, but this is not required.  Implementations are free to perform matching directly against the [=/part list=] when possible; e.g. when there are no custom regexp matching groups.  If there are custom regular expressions, however, its important that they should be immediately evaluated in the [=compile a component=] algorithm so an error can be thrown if they are invalid.
   1. Let |pattern string| be the result of running [=generate a pattern string=] given |part list| and |options|.


### PR DESCRIPTION
Updates the regular expression part to work with `v` flag instead of `u`.

This will fix #178.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/pull/188.html" title="Last updated on Sep 13, 2023, 2:20 PM UTC (27334d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/urlpattern/188/d9af8a1...27334d0.html" title="Last updated on Sep 13, 2023, 2:20 PM UTC (27334d0)">Diff</a>